### PR TITLE
ci: run unit tests + coverage on push/PR via GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,36 @@
+name: tests
+
+on:
+  push:
+    branches: ["main", "dev", "ci/**"]
+  pull_request:
+    branches: ["main", "dev"]
+
+# Cancel superseded runs on the same ref to save CI minutes.
+concurrency:
+  group: tests-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  unit:
+    name: unit tests (py3.11)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: pyproject.toml
+
+      - name: Install package (with dev extras)
+        # osgeo/GDAL is lazy-imported (only merge_rasters needs it) so the
+        # unit suite runs on plain pip wheels — no conda required. The heavy
+        # integration/regression/slow tests are deselected below.
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e ".[dev]"
+
+      - name: Run unit tests
+        run: pytest tests/unit -m "not integration and not regression and not slow"

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -32,5 +32,18 @@ jobs:
           python -m pip install --upgrade pip
           pip install -e ".[dev]"
 
-      - name: Run unit tests
-        run: pytest tests/unit -m "not integration and not regression and not slow"
+      - name: Run unit tests (with coverage)
+        # Coverage is reported, never enforced — no --cov-fail-under, so a low
+        # number never fails the run.
+        run: >
+          pytest tests/unit
+          -m "not integration and not regression and not slow"
+          --cov=pwa_tools --cov-report=term-missing --cov-report=xml
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-pwa-tools
+          path: coverage.xml
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -9,8 +9,12 @@ pwa_tools/WBT/__pycache__/
 # Ignore whitebox
 WBT/
 
-# pytest
+# pytest / coverage
 .pytest_cache/
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
 
 # Local tooling config
 .gh_config/


### PR DESCRIPTION
## What

Adds a GitHub Actions workflow (`tests`) that runs the `pwa-tools` unit suite on every push and PR.

## Details

- `ubuntu-latest`, Python 3.11, **pip-only** — `osgeo`/GDAL is lazy-imported (only `merge_rasters` needs it), so the unit suite installs from plain wheels with no conda.
- Installs `pip install -e ".[dev]"` and runs `pytest tests/unit -m "not integration and not regression and not slow"`.
- The deselected `integration`/`regression`/`slow` tests need the ~6 GB reference dataset or external binaries (Raven, WhiteboxTools, gdal) that CI can't provide; their conftest already skips them gracefully.
- pip caching + concurrency-cancel for superseded runs.

## Verification

Ran the exact CI command locally: **93 unit tests pass**.


## Coverage (non-gating)

The test run now also produces a coverage report (`--cov`, uploaded as a `coverage.xml` artifact). There is **no `--cov-fail-under` threshold** — coverage is informational and never fails the build. Local `.coverage` / `coverage.xml` outputs are gitignored.