### PR TITLE
test: local-only Step 0 module-CLI integration test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+# Test targets for pwa-tools.
+#
+#   make test         unit tests (mirrors GitHub CI)
+#   make integration  module-CLI e2e on real data (skips without PWA_STEP0_CONFIG)
+#   make regression   WhiteboxTools + gdal end-to-end vs the grassmere baseline
+#                      (skips without the reference dataset)
+#
+# See tests/integration/README.md and tests/regression/ for inputs.
+.PHONY: test integration regression
+
+test:
+	pytest tests/unit -m "not integration and not regression and not slow"
+
+integration:
+	pytest tests/integration
+
+regression:
+	pytest tests/regression -m regression

--- a/tests/integration/README.md
+++ b/tests/integration/README.md
@@ -1,0 +1,32 @@
+# pwa-tools integration tests
+
+Drives **Step 0 through its module CLI** (`python -m pwa_tools.run_step0`) on a
+real config — the one path `tests/regression/` doesn't cover (regression calls
+the Step 0 functions directly; this exercises argument parsing, config loading,
+and the `__main__` wiring on real data). **Local-only** — GitHub CI runs `pytest
+tests/unit`.
+
+> The deeper Step 0 science (WhiteboxTools + gdalwarp end-to-end vs the
+> grassmere baseline) lives in `tests/regression/` — run it with
+> `make regression`.
+
+Skips cleanly when its inputs are absent — except the missing-config error-path
+check, which needs nothing and always runs.
+
+## Inputs (environment)
+
+| Variable | Purpose |
+|---|---|
+| `PWA_STEP0_CONFIG` | Path to a filled-in `pwa_config.yml` (`python -m pwa_tools.init_config`) |
+
+A successful run also needs WhiteboxTools + GDAL available (as Step 0 always
+does).
+
+## Run
+
+```bash
+make integration
+
+# Or directly:
+PWA_STEP0_CONFIG=/path/to/pwa_config.yml pytest tests/integration -v
+```

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,38 @@
+"""Fixtures for pwa_tools integration tests — real binaries / real data.
+
+Local-only: GitHub CI runs ``pytest tests/unit`` and never enters this
+directory. The deeper Step 0 science (WhiteboxTools + gdalwarp end-to-end on
+real grassmere data) already lives in ``tests/regression/``; the integration
+test here covers the one path regression doesn't — driving Step 0 through its
+**module CLI** (``python -m pwa_tools.run_step0``) on a real config.
+
+Inputs are discovered from the environment so no machine-specific path is baked
+into the test:
+
+* ``PWA_STEP0_CONFIG`` — path to a filled-in ``pwa_config.yml`` (generate one
+  with ``pwa-init-hydrocondition`` / ``python -m pwa_tools.init_config``).
+
+Skips cleanly when unset.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.fixture
+def step0_config_path() -> Path:
+    """Path to a real ``pwa_config.yml`` from ``$PWA_STEP0_CONFIG``, or skip."""
+    config_path = os.environ.get("PWA_STEP0_CONFIG")
+    if not config_path:
+        pytest.skip(
+            "Set PWA_STEP0_CONFIG to a filled-in pwa_config.yml "
+            "(see `python -m pwa_tools.init_config`) to run the Step 0 CLI e2e."
+        )
+    path = Path(config_path)
+    if not path.is_file():
+        pytest.fail(f"PWA_STEP0_CONFIG={config_path!r} is not a file")
+    return path

--- a/tests/integration/test_step0_cli_e2e.py
+++ b/tests/integration/test_step0_cli_e2e.py
@@ -1,0 +1,57 @@
+"""End-to-end: drive Step 0 through its module CLI on a real config.
+
+Why this exists
+---------------
+``tests/regression/`` already runs the Step 0 science (WhiteboxTools + gdalwarp)
+end-to-end by calling the functions directly. What it does **not** exercise is
+the user-facing entry point: argument parsing, config loading via
+``PwaConfig.from_yaml``, the missing-config exit code, and the
+``run_step0``-from-``__main__`` wiring — all on real data. A broken CLI wrapper
+(or a regression in entry-point plumbing) would pass every regression test yet
+break every user.
+
+Run with::
+
+    PWA_STEP0_CONFIG=/path/to/pwa_config.yml pytest tests/integration
+
+Marked ``integration`` + ``slow`` (a real Step 0 run is minutes, not seconds)
+and ``regression`` (needs real watershed inputs). Skips without the config.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+
+import pytest
+
+
+@pytest.mark.integration
+@pytest.mark.regression
+@pytest.mark.slow
+def test_run_step0_module_cli_succeeds(step0_config_path):
+    """``python -m pwa_tools.run_step0 --config <real>`` exits 0 on real data."""
+    completed = subprocess.run(
+        [sys.executable, "-m", "pwa_tools.run_step0", "--config", str(step0_config_path)],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 0, (
+        f"Step 0 CLI failed (exit {completed.returncode}).\n"
+        f"stdout:\n{completed.stdout}\nstderr:\n{completed.stderr}"
+    )
+    # The wrapper prints the two headline outputs on success.
+    assert "Depression depths" in completed.stdout
+
+
+def test_run_step0_module_cli_reports_missing_config():
+    """A no-binary, no-data smoke check of the CLI's error path: a missing
+    config yields a non-zero exit and a helpful message. Runs everywhere, so
+    it's the one integration-dir test that doesn't need real inputs."""
+    completed = subprocess.run(
+        [sys.executable, "-m", "pwa_tools.run_step0", "--config", "definitely_missing.yml"],
+        capture_output=True,
+        text=True,
+    )
+    assert completed.returncode == 1
+    assert "Config file not found" in completed.stderr


### PR DESCRIPTION
## What

Adds a **local-only integration test** driving Step 0 through its module CLI (`python -m pwa_tools.run_step0`) on a real config.

## Why

`tests/regression/` already runs the Step 0 science (WhiteboxTools + gdalwarp) by calling functions directly. The one gap is the user-facing entry point — argument parsing, config loading, `__main__` wiring on real data. A broken CLI wrapper passes every regression test yet breaks every user.

- `integration` + `regression` + `slow`: `python -m pwa_tools.run_step0 --config <real>` exits 0 on real data and prints its outputs. Gated on `PWA_STEP0_CONFIG`.
- A no-input error-path check (missing config → exit 1) that always runs.

## Local-only

GitHub CI runs `pytest tests/unit`; this suite lives in `tests/integration` and skips cleanly without `PWA_STEP0_CONFIG`. Adds a `Makefile` (`make integration` / `regression`) and a README.

## Verification

`pytest tests/integration` here: the real-data test skips with guidance, the error-path test passes; unit suite unaffected (96 pass).
